### PR TITLE
Card solr fields

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -50,7 +50,7 @@ class CatalogController < ApplicationController
     config.add_nav_action(:search_history, partial: 'blacklight/nav/search_history')
 
     # solr field configuration for document/show views
-    #config.show.title_field = 'title_tsim'
+    config.show.title_field = 'title_tsim'
     #config.show.display_type_field = 'format'
     #config.show.thumbnail_field = 'thumbnail_path_ss'
 
@@ -78,21 +78,30 @@ class CatalogController < ApplicationController
     #  (useful when user clicks "more" on a large facet and wants to navigate alphabetically across a large set of results)
     # :index_range can be an array or range of prefixes that will be used to create the navigation (note: It is case sensitive when searching values)
 
-    config.add_facet_field 'format', label: 'Format'
-    config.add_facet_field 'pub_date_ssim', label: 'Publication Year', single: true
-    config.add_facet_field 'subject_ssim', label: 'Topic', limit: 20, index_range: 'A'..'Z'
-    config.add_facet_field 'language_ssim', label: 'Language', limit: true
-    config.add_facet_field 'lc_1letter_ssim', label: 'Call Number'
-    config.add_facet_field 'subject_geo_ssim', label: 'Region'
-    config.add_facet_field 'subject_era_ssim', label: 'Era'
+    config.add_facet_field 'card_request_type_ssi', label: 'Card Request Type', limit: true, index_range: 'A'..'Z'
+    config.add_facet_field 'card_i_or_p_ssi', label: 'Card Investigation/Project'
+    config.add_facet_field 'card_requester_name_ssim', label: 'Card Requester Name', limit: true, index_range: 'A'..'Z'
+    config.add_facet_field 'card_requester_div_ssim', label: 'Card Requester Divison', limit: true, index_range: 'A'..'Z'
+    config.add_facet_field 'card_benefits_tsim', label: 'Card Benefits', limit: true, index_range: 'A'..'Z'
+    config.add_facet_field 'card_priority_ssi', label: 'Card Priority', limit: true, index_range: 'A'..'Z'
+    config.add_facet_field 'card_sponsor_ssim', label: 'Card Sponsor', limit: true, index_range: 'A'..'Z'
+    config.add_facet_field 'card_start_cycle_dtsi', label: 'Card Start Cycle', limit: true, index_range: 'A'..'Z'
+    config.add_facet_field 'card_done_cycle_dtsi', label: 'Card Done Cycle', limit: true, index_range: 'A'..'Z'
+    config.add_facet_field 'card_card_status_tsi', label: 'Card Status', limit: true, index_range: 'A'..'Z'
+    config.add_facet_field 'card_lit_lead_tsim', label: 'Card LIT Lead', limit: true, index_range: 'A'..'Z'
+    config.add_facet_field 'card_lit_dept_tsim', label: 'Card LIT Dept', limit: true, index_range: 'A'..'Z'
+    config.add_facet_field 'card_service_lead_tsim', label: 'Card Service Lead', limit: true, index_range: 'A'..'Z'
+    # config.add_facet_field 'card_recorded_on_dtsi', label: 'Card Recorded Date', limit: true, index_range: 'A'..'Z'
+    # config.add_facet_field 'card_created_at_dtsi', label: 'Card Created Date', limit: true, index_range: 'A'..'Z'
+    # config.add_facet_field 'card_updated_at_dtsi', label: 'Card Updated Date', limit: true, index_range: 'A'..'Z'
 
-    config.add_facet_field 'example_pivot_field', label: 'Pivot Field', :pivot => ['format', 'language_ssim']
+    # config.add_facet_field 'example_pivot_field', label: 'Pivot Field', :pivot => ['format', 'language_ssim']
 
-    config.add_facet_field 'example_query_facet_field', label: 'Publish Date', :query => {
-       :years_5 => { label: 'within 5 Years', fq: "pub_date_ssim:[#{Time.zone.now.year - 5 } TO *]" },
-       :years_10 => { label: 'within 10 Years', fq: "pub_date_ssim:[#{Time.zone.now.year - 10 } TO *]" },
-       :years_25 => { label: 'within 25 Years', fq: "pub_date_ssim:[#{Time.zone.now.year - 25 } TO *]" }
-    }
+    # config.add_facet_field 'example_query_facet_field', label: 'Publish Date', :query => {
+    #    :years_5 => { label: 'within 5 Years', fq: "pub_date_ssim:[#{Time.zone.now.year - 5 } TO *]" },
+    #    :years_10 => { label: 'within 10 Years', fq: "pub_date_ssim:[#{Time.zone.now.year - 10 } TO *]" },
+    #    :years_25 => { label: 'within 25 Years', fq: "pub_date_ssim:[#{Time.zone.now.year - 25 } TO *]" }
+    # }
 
 
     # Have BL send all facet field names to Solr, which has been the default
@@ -102,32 +111,54 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
-    config.add_index_field 'title_tsim', label: 'Title'
-    config.add_index_field 'title_vern_ssim', label: 'Title'
-    config.add_index_field 'author_tsim', label: 'Author'
-    config.add_index_field 'author_vern_ssim', label: 'Author'
-    config.add_index_field 'format', label: 'Format'
-    config.add_index_field 'language_ssim', label: 'Language'
-    config.add_index_field 'published_ssim', label: 'Published'
-    config.add_index_field 'published_vern_ssim', label: 'Published'
-    config.add_index_field 'lc_callnum_ssim', label: 'Call number'
 
+    # Card index fields
+    config.add_index_field 'card_titlel_tsim', label: 'Title'
+    config.add_index_field 'card_requester_name_ssim', label: 'Requester'
+    config.add_index_field 'card_request_type_ssi', label: 'Request Type'
+    config.add_index_field 'card_i_or_p_ssi', label: 'Investigation/Project'
+    config.add_index_field 'card_priority_ssi', label: 'Priority'
+    config.add_index_field 'card_requester_div_ssim', label: 'Requester Divison'
+    config.add_index_field 'card_card_status_tsi', label: 'Card Status'
+    config.add_index_field 'card_start_cycle_dtsi', label: 'Start Cycle'
+    config.add_index_field 'card_done_cycle_dtsi', label: 'Done Cycle'
+    
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
-    config.add_show_field 'title_tsim', label: 'Title'
-    config.add_show_field 'title_vern_ssim', label: 'Title'
-    config.add_show_field 'subtitle_tsim', label: 'Subtitle'
-    config.add_show_field 'subtitle_vern_ssim', label: 'Subtitle'
-    config.add_show_field 'author_tsim', label: 'Author'
-    config.add_show_field 'author_vern_ssim', label: 'Author'
-    config.add_show_field 'format', label: 'Format'
-    config.add_show_field 'url_fulltext_ssim', label: 'URL'
-    config.add_show_field 'url_suppl_ssim', label: 'More Information'
-    config.add_show_field 'language_ssim', label: 'Language'
-    config.add_show_field 'published_ssim', label: 'Published'
-    config.add_show_field 'published_vern_ssim', label: 'Published'
-    config.add_show_field 'lc_callnum_ssim', label: 'Call number'
-    config.add_show_field 'isbn_ssim', label: 'ISBN'
+    # Card show fields
+    config.add_show_field 'card_titlel_tsim', label: 'Title'
+    config.add_show_field 'card_request_type_ssi', label: 'Request Type'
+    config.add_show_field 'card_i_or_p_ssi', label: 'Investigation/Project'
+    config.add_show_field 'card_requester_name_ssim', label: 'Requester'
+    config.add_show_field 'card_requester_email_ssim', label: 'Requester Email'
+    config.add_show_field 'card_requester_div_ssim', label: 'Requester Divison'
+    config.add_show_field 'card_contact_names_ssim', label: 'Contact Names'
+    config.add_show_field 'card_short_description_ssi', label: 'Short Description'
+    config.add_show_field 'card_prev_work_tsim', label: 'Previous Work'
+    config.add_show_field 'card_accomplish_tsim', label: 'Accomplished'
+    config.add_show_field 'card_benefits_tsim', label: 'Benefits'
+    config.add_show_field 'card_goal_alignment_tsim', label: 'Goal Alignment'
+    config.add_show_field 'card_at_stake_tsm', label: 'At Stake'
+    config.add_show_field 'card_ext_pressure_tsm', label: 'External Pressure'
+    config.add_show_field 'card_non_tech_tsm', label: 'Non-Technical'
+    config.add_show_field 'card_time_constraints_tsm', label: 'Time Constraints'
+    config.add_show_field 'card_priority_ssi', label: 'Priority'
+    config.add_show_field 'card_sponsor_ssim', label: 'Sponsor'
+    config.add_show_field 'card_more_info_tsm', label: 'More Info'
+    config.add_show_field 'card_short_name_ssi', label: 'Short Name'
+    config.add_show_field 'card_start_cycle_dtsi', label: 'Start Cycle'
+    config.add_show_field 'card_done_cycle_dtsi', label: 'Done Cycle'
+    config.add_show_field 'card_card_status_tsi', label: 'Card Status'
+    config.add_show_field 'card_ext_link_tsm', label: 'External Link'
+    config.add_show_field 'card_lit_lead_tsim' , label: 'LIT Lead'
+    config.add_show_field 'card_lit_dept_tsim', label: 'LIT Dept'
+    config.add_show_field 'card_service_lead_tsim', label: 'Service Lead'
+    config.add_show_field 'card_other_contacts_tsm', label: 'Other Contacts'
+    config.add_show_field 'card_comments_tsim', label: 'Comments'
+    config.add_show_field 'card_recorded_on_dtsi', label: 'Recorded Date'
+    config.add_show_field 'card_created_at_dtsi', label: 'Created Date'
+    config.add_show_field 'card_updated_at_dtsi', label: 'Updated Data'
+
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -1,2 +1,55 @@
 class Card < ApplicationRecord
+	after_save :index_record
+	before_destroy :remove_from_index
+
+	attr_accessible :id, :request_type, :i_or_p, :requester_name, :requester_email, :requester_div, :contact_names, :title, :short_description, :prev_work, :accomplish, :benefits, :goal_alignment, :at_stake, :ext_pressure, :non_tech, :time_constraints, :priority, :sponsor, :more_info, :short_name, :start_cycle, :done_cycle, :card_status, :ext_link, :lit_lead, :lit_dept, :service_lead, :other_contacts, :comments, :recorded_on, :created_at, :updated_at
+  
+
+	def to_solr
+		{ 
+			'id' => id,
+			'card_request_type_ssi' => request_type
+			'card_i_or_p_ssi' => i_or_p
+			'card_requester_name_ssim' => requester_name
+			'card_requester_email_ssim' => requester_email
+			'card_requester_div_ssim' => requester_div
+			'card_contact_names_ssim' => contact_names
+			'card_titlel_tsim' => title
+			'card_short_description_ssi' => short_description
+			'card_prev_work_tsim' => prev_work
+			'card_accomplish_tsim' => accomplish
+			'card_benefits_tsim' => benefits
+			'card_goal_alignment_tsim' => goal_alignment
+			'card_at_stake_tsm' => at_stake
+			'card_ext_pressure_tsm' => ext_pressure
+			'card_non_tech_tsm' => non_tech
+			'card_time_constraints_tsm' => time_constraints
+			'card_priority_ssi' => priority
+			'card_sponsor_ssim' => sponsor
+			'card_more_info_tsm' => more_info
+			'card_short_name_ssi' => short_name
+			'card_start_cycle_dtsi' => start_cycle
+			'card_done_cycle_dtsi' => done_cycle
+			'card_card_status_tsi' => card_status
+			'card_ext_link_tsm' => ext_link
+			'card_lit_lead_tsim' => lit_lead
+			'card_lit_dept_tsim' => lit_dept
+			'card_service_lead_tsim' => service_lead
+			'card_other_contacts_tsm' => other_contacts
+			'card_comments_tsim' => comments
+			'card_recorded_on_dtsi' => recorded_on
+			'card_created_at_dtsi' => created_at
+			'card_updated_at_dtsi' => updated_at
+		}
+	end
+
+  def index_record
+    SolrService.add(self.to_solr)
+    SolrService.commit
+  end
+
+  def remove_from_index
+    SolrService.delete_by_id(self.id)
+    SolrService.commit
+  end
 end


### PR DESCRIPTION
Summary:
Modified app/controllers/catalog_controller.rb to focus on card Solr fields for indexing, display, and faceting. Maybe still need a few changes.
Added app/models/card.rb with a to_solr method to a card to Solr - Just realized we may not need to separate indexer in BL 7.x