### PR TITLE
cycle save was being indexed did not work in  production.

### DIFF
--- a/app/models/cycle_review.rb
+++ b/app/models/cycle_review.rb
@@ -1,6 +1,8 @@
 class CycleReview < ApplicationRecord
 	belongs_to :card
+    after_save :index_record
 
+  def index_record
 	conn = Blacklight.default_index.connection
   	doc = { 
 			'id' => self.id,
@@ -13,4 +15,6 @@ class CycleReview < ApplicationRecord
 		}
 	conn.add doc
 	conn.commit
+  end
+  
 end

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,0 +1,4 @@
+hostname: fdtool-demo.www.lib.umich.edu
+
+rails:
+  secret_key_base: 20a666531ae2cf29a70d5b078df8e6b1c4c6230aa091a967d29ca6d6144bd31e7a9278046621ffae9ab5d5198a89b0ff126a174d320f1f4a2a6298afcae28196


### PR DESCRIPTION
The way cycle was being indexed was not working in production serer.  It should be indexed just like card.  Also, production.yml file added so we can run it in production mode on local

`RAILS_ENV=production RAILS_SERVE_STATIC_FILES=1 bundle exec rails s`

RAILS_SERVE_STATIC_FILES is there to serve assets directly in production when running locally, which is by default disabled.

Also, when assets are not showing up locally in production mode locally, run this:

`RAILS_ENV=production bundle exec rake assets:precompile`
 