### PR TITLE
Install mysql2 gem in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,9 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
+group :production do
+  gem 'mysql2'
+end
 
 gem 'googlecharts'
 


### PR DESCRIPTION
In order to use mysql instead of sqlite in production, as someone configuring the production deployment workflow, I need the mysql2 gem to be in the Gemfile. I've added it to the `:production` group, so it shouldn't affect any development environments.